### PR TITLE
Configure Renovate to automerge all updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,14 +4,7 @@
     "config:recommended"
   ],
   "separateMinorPatch": true,
-  "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "automerge": true
-    }
-  ],
+  "automerge": true,
   "customManagers": [
     {
       "description": "Update Helm Charts used in Terraform",


### PR DESCRIPTION
This change modifies the Renovate configuration to enable automerge for all update types. Previously, automerge was only enabled for patch updates.